### PR TITLE
Fix Compilation of readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ Create your Lambda function by extending ZLambda
 import zio.Console._
 import zio._
 import zio.lambda._
+import zio.lambda.event._
 
 object SimpleHandler extends ZLambda[KinesisEvent, String] {
 
-  override def apply(event: KinesisEvent, context: Context): RIO[ZEnv, String] =
+  override def apply(event: KinesisEvent, context: Context): Task[String] =
     for {
-      _ <- printLine(event.message)
+      _ <- printLine(event)
     } yield "Handler ran successfully"
 }
 ```


### PR DESCRIPTION
Hi!  I found the example handler in the README doesn't compile under `v1.0.0-RC6`, this PR fixes this by importing `KinesisEvent` and printing the event itself rather than `event.message`.

I hope this is useful ~ thanks Laurence