### PR TITLE
Fixed #130 - make Lambda-Runtime-Trace-Id optional

### DIFF
--- a/lambda/src/test/scala/zio/lambda/internal/InvocationRequestGen.scala
+++ b/lambda/src/test/scala/zio/lambda/internal/InvocationRequestGen.scala
@@ -47,7 +47,7 @@ object InvocationRequestGen {
       id                    <- Gen.string
       remainingTimeInMillis <- Gen.long
       invokedFunctionArn    <- Gen.string
-      xrayTraceId           <- Gen.string
+      xrayTraceId           <- Gen.option(Gen.string)
       clientContext         <- Gen.option(genClientContext)
       cognitoIdentity       <- Gen.option(genCognitoIdentity)
       payload               <- Gen.string

--- a/lambda/src/test/scala/zio/lambda/internal/InvocationRequestSpec.scala
+++ b/lambda/src/test/scala/zio/lambda/internal/InvocationRequestSpec.scala
@@ -15,7 +15,12 @@ object InvocationRequestSpec extends ZIOSpecDefault {
           check(InvocationRequestGen.gen) { invocationRequest =>
             val headers = new java.util.HashMap[String, java.util.List[String]]()
             headers.put("Lambda-Runtime-Aws-Request-Id", java.util.Collections.singletonList(invocationRequest.id))
-            headers.put("Lambda-Runtime-Trace-Id", java.util.Collections.singletonList(invocationRequest.xrayTraceId))
+            headers.put(
+              "Lambda-Runtime-Trace-Id",
+              invocationRequest.xrayTraceId
+                .map(java.util.Collections.singletonList[String])
+                .getOrElse(java.util.Collections.emptyList())
+            )
             headers.put(
               "Lambda-Runtime-Invoked-Function-Arn",
               java.util.Collections.singletonList(invocationRequest.invokedFunctionArn)


### PR DESCRIPTION
According to [AWS Lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html) there is a header in InvocationNext response named Lambda-Runtime-Trace-Id related to [XRay Tracing](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html). But if your Lambda [has configuration with disabled tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) (that is default behavior for custom runtimes which is in its turn used to run GraalVM based lambda based on zio-lambda) - this header won't come that case NullPointerException.
So this header was changed to `Optional[String]`