### PR TITLE
Fixed #191 - APIGatewayV2HTTPRequestContext.authorizer must be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 A ZIO-based AWS Custom Runtime compatible with GraalVM Native Image.
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-lambda/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-lambda_2.13/) [![ZIO Lambda](https://img.shields.io/github/stars/zio/zio-lambda?style=social)](https://github.com/zio/zio-lambda)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-lambda/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-lambda_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-lambda_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-lambda-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-lambda-docs_2.13) [![ZIO Lambda](https://img.shields.io/github/stars/zio/zio-lambda?style=social)](https://github.com/zio/zio-lambda)
 
 ## Installation
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-lambda" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-lambda" % "1.0.2"
 
 // Optional dependencies
-libraryDependencies += "dev.zio" %% "zio-lambda-event"    % "<version>"
-libraryDependencies += "dev.zio" %% "zio-lambda-response" % "<version>"
+libraryDependencies += "dev.zio" %% "zio-lambda-event"    % "1.0.2"
+libraryDependencies += "dev.zio" %% "zio-lambda-response" % "1.0.2"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 A ZIO-based AWS Custom Runtime compatible with GraalVM Native Image.
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-lambda/workflows/CI/badge.svg) [![Sonatype Releases](https://img.shields.io/nexus/r/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Release)](https://oss.sonatype.org/content/repositories/releases/dev/zio/zio-lambda_2.13/) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-lambda_2.13/) [![javadoc](https://javadoc.io/badge2/dev.zio/zio-lambda-docs_2.13/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-lambda-docs_2.13) [![ZIO Lambda](https://img.shields.io/github/stars/zio/zio-lambda?style=social)](https://github.com/zio/zio-lambda)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-lambda/workflows/CI/badge.svg) [![Sonatype Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/dev.zio/zio-lambda_2.13.svg?label=Sonatype%20Snapshot)](https://oss.sonatype.org/content/repositories/snapshots/dev/zio/zio-lambda_2.13/) [![ZIO Lambda](https://img.shields.io/github/stars/zio/zio-lambda?style=social)](https://github.com/zio/zio-lambda)
 
 ## Installation
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-lambda" % "1.0.1"
+libraryDependencies += "dev.zio" %% "zio-lambda" % "<version>"
 
 // Optional dependencies
-libraryDependencies += "dev.zio" %% "zio-lambda-event"    % "1.0.1"
-libraryDependencies += "dev.zio" %% "zio-lambda-response" % "1.0.1"
+libraryDependencies += "dev.zio" %% "zio-lambda-event"    % "<version>"
+libraryDependencies += "dev.zio" %% "zio-lambda-response" % "<version>"
 ```
 
 ## Usage

--- a/lambda-event/src/main/scala/zio/lambda/event/APIGatewayV2HttpEvent.scala
+++ b/lambda-event/src/main/scala/zio/lambda/event/APIGatewayV2HttpEvent.scala
@@ -31,7 +31,7 @@ final case class APIGatewayV2HTTPRequestContext(
   time: String,
   timeEpoch: Long,
   http: APIGatewayV2HTTPRequestContextHttp,
-  authorizer: APIGatewayV2HTTPRequestContextAuthorizer,
+  authorizer: Option[APIGatewayV2HTTPRequestContextAuthorizer],
   requestId: String
 )
 


### PR DESCRIPTION
fixes #191