### PR TITLE
Allows to use non-english-language characters in responses.

### DIFF
--- a/lambda/src/main/scala/zio/lambda/internal/RuntimeApiLive.scala
+++ b/lambda/src/main/scala/zio/lambda/internal/RuntimeApiLive.scala
@@ -43,12 +43,14 @@ final case class RuntimeApiLive(environment: LambdaEnvironment) extends RuntimeA
     val conn = url.openConnection().asInstanceOf[HttpURLConnection]
     conn.setRequestMethod("POST")
     conn.setRequestProperty("Content-Type", "application/json")
-    conn.setFixedLengthStreamingMode(invocationResponse.payload.length())
+    val payload      = invocationResponse.payload
+    val payloadBytes = payload.getBytes("UTF-8")
+    conn.setFixedLengthStreamingMode(payloadBytes.length)
     conn.setDoOutput(true)
 
     ZIO.attempt {
       val outputStream = conn.getOutputStream()
-      outputStream.write(invocationResponse.payload.getBytes())
+      outputStream.write(payloadBytes)
       try conn.getInputStream().close()
       catch { case _: Throwable => () } // Reusing connection
     }

--- a/lambda/src/test/scala/zio/lambda/internal/RuntimeApiLiveSpec.scala
+++ b/lambda/src/test/scala/zio/lambda/internal/RuntimeApiLiveSpec.scala
@@ -4,7 +4,7 @@ import zio._
 import zio.test.Assertion._
 import zio.test._
 
-import java.net.ServerSocket
+import java.net.{ConnectException, ServerSocket}
 
 object RuntimeApiLiveSpec extends ZIOSpecDefault {
 
@@ -21,7 +21,7 @@ object RuntimeApiLiveSpec extends ZIOSpecDefault {
                  val clientSocket = serverSocket.accept()
                  clientSocket.close()
                }.fork
-          res <- runtime.sendInvocationResponse(resp)
+          res <- runtime.sendInvocationResponse(resp).retryWhile(_.isInstanceOf[ConnectException])
         } yield assert(res)(isUnit)
 
       }

--- a/lambda/src/test/scala/zio/lambda/internal/RuntimeApiLiveSpec.scala
+++ b/lambda/src/test/scala/zio/lambda/internal/RuntimeApiLiveSpec.scala
@@ -1,0 +1,30 @@
+package zio.lambda.internal
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+import java.net.ServerSocket
+
+object RuntimeApiLiveSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("RuntimeApiLiveSpec spec")(
+      test("sendInvocationResponse should not throw any error when UTF-8 characters are provided") {
+
+        val env     = LambdaEnvironment("localhost:8085", "", "", 0, "", "", "", "")
+        val resp    = InvocationResponse("id", "payload with UTF-8 characters: 'тест'")
+        val runtime = new RuntimeApiLive(env)
+        for {
+          _ <- ZIO.attempt {
+                 val serverSocket = new ServerSocket(8085)
+                 val clientSocket = serverSocket.accept()
+                 clientSocket.close()
+               }.fork
+          res <- runtime.sendInvocationResponse(resp)
+        } yield assert(res)(isUnit)
+
+      }
+    )
+
+}


### PR DESCRIPTION
This PR allows `zio-lambda` to send responses that contain characters from languages other than English. Currently, if such a character appears in the response, `zio-lambda` throws an exception. This is the same fix that was done for `postRequest` method earlier. 