### PR TITLE
CI: Add JDK 21 and JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17' ]
+        java: [ '17', '21', '25' ]
         scala: [ '2.12.x', '2.13.x', '3.x' ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add JDK 21 and JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25