### PR TITLE
fix: md5OfMessageAttributes not being optional

### DIFF
--- a/lambda-event/src/main/scala/zio/lambda/event/SQSEvent.scala
+++ b/lambda-event/src/main/scala/zio/lambda/event/SQSEvent.scala
@@ -13,7 +13,7 @@ final case class SQSRecord(
   receiptHandle: String,
   body: String,
   md5OfBody: String,
-  md5OfMessageAttributes: String,
+  md5OfMessageAttributes: Option[String],
   eventSourceARN: String,
   eventSource: String,
   awsRegion: String,

--- a/lambda-event/src/test/scala/zio/lambda/event/JavaLambdaEventsGen.scala
+++ b/lambda-event/src/test/scala/zio/lambda/event/JavaLambdaEventsGen.scala
@@ -159,7 +159,7 @@ object JavaLambdaEventsGen {
       receiptHandle          <- Gen.string
       body                   <- Gen.string
       md5OfBody              <- Gen.string
-      md5OfMessageAttributes <- Gen.string
+      md5OfMessageAttributes <- Gen.option(Gen.string)
       eventSourceArn         <- Gen.string
       eventSource            <- Gen.string
       awsRegion              <- Gen.string
@@ -171,7 +171,7 @@ object JavaLambdaEventsGen {
       sqsMessage.setReceiptHandle(receiptHandle)
       sqsMessage.setBody(body)
       sqsMessage.setMd5OfBody(md5OfBody)
-      sqsMessage.setMd5OfMessageAttributes(md5OfMessageAttributes)
+      md5OfMessageAttributes.foreach(attributes => sqsMessage.setMd5OfMessageAttributes(attributes))
       sqsMessage.setEventSourceArn(eventSourceArn)
       sqsMessage.setEventSource(eventSource)
       sqsMessage.setAwsRegion(awsRegion)


### PR DESCRIPTION
Since md5OfMessageAttributes is an optional property, I have updated it.
For reference, the following link provides the TypeScript type definitions.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/trigger/sqs.d.ts#L15